### PR TITLE
pass fields from config to override default response attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,10 @@ class AD {
     config.domain = String(config.user).split('@')[1];
 
     if (config.baseDN === undefined) {
-      config.baseDN = config.domain.split('.').map(n => `DC=${n}`).join(',');
+      config.baseDN = config.domain
+        .split('.')
+        .map(n => `DC=${n}`)
+        .join(',');
     }
 
     config = Object.assign(configFile, config);
@@ -84,7 +87,8 @@ class AD {
       password: config.pass,
       tlsOptions: {
         rejectUnauthorized: false
-      }
+      },
+      attributes: config.fields
     });
   }
 

--- a/readme.md
+++ b/readme.md
@@ -74,9 +74,18 @@ const AD = require('ad');
 // Your AD account should be a member
 // of the Administrators group.
 const ad = new AD({
-	url: "ldaps://127.0.0.1",
-	user: "dthree@acme.co",
-	pass: "howinsecure"
+	url: "ldaps://127.0.0.1", // mandatory
+	user: "dthree@acme.co",   // mandatory
+	pass: "howinsecure",      // mandatory
+	baseDN: "dc=ad",          // optional
+	fields: {                 // optional
+		user: [
+			'fields to include in response'
+		],
+		group: [
+			'fields to include in response'
+		]
+	}
 });
 
 ad.user().get().then(users => {


### PR DESCRIPTION
In project in our company we need to access attribute `managedObjects` on object `user`. In current implementation we cannot access this attribute because attributes in response are limited by default attributes which are set here https://github.com/jsumners/node-activedirectory/blob/jsumners/lib/activedirectory.js#L55.

So we need to override the defaultAttributes object and idea is to pass down default response attributes from construct of AD.

Please, let mi know, if there is a better way to solve this problem.

Thanks.