### PR TITLE
Allow to choose object class when adding user

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -165,6 +165,7 @@ Creates a new user. Returns the created user object.
 * `email`: String
 * `title`: String
 * `location`: String
+* `objectClass`: String
 
 If not specified, the first and last name will be based on the `commonName`.
 

--- a/src/user.js
+++ b/src/user.js
@@ -38,7 +38,8 @@ module.exports = {
         email,
         title,
         phone,
-        location
+        location,
+        objectClass
       } = opts;
 
       let { passwordExpires, enabled } = opts;
@@ -57,12 +58,21 @@ module.exports = {
 
       location = parseLocation(location);
 
+      // Will use passed (if passed) objectClass if it in fact a correct type.
+      objectClass = ['user', this.config.defaults.userObjectClass].includes(
+        objectClass
+      )
+        ? objectClass
+        : this.config.defaults.userObjectClass;
+
       let valid =
         email && String(email).indexOf('@') === -1
           ? 'Invalid email address.'
           : !commonName
-            ? 'A commonName is required.'
-            : !userName ? 'A userName is required.' : true;
+          ? 'A commonName is required.'
+          : !userName
+          ? 'A userName is required.'
+          : true;
 
       if (valid !== true) {
         /* istanbul ignore next */
@@ -79,7 +89,7 @@ module.exports = {
         telephone: phone,
         userPrincipalName: `${userName}@${this.config.domain}`,
         sAMAccountName: userName,
-        objectClass: this.config.defaults.userObjectClass,
+        objectClass: objectClass,
         userPassword: ssha.create(pass)
       };
 


### PR DESCRIPTION
Instead of always creating a user as `inetOrgPerson`, I needed a way to create a user with the object class `user`.